### PR TITLE
Ensure pytest imports bmi without python -m

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Clasificación: Normal
 
 ## Running tests
 
-To run the unit tests, install `pytest` and execute:
+To run the unit tests, install `pytest` and execute the command from the
+repository root.  The test suite adjusts `sys.path` automatically so running
+`pytest` directly works without using `python -m`:
 
 ```bash
 pytest

--- a/tests/test_bmi.py
+++ b/tests/test_bmi.py
@@ -1,4 +1,10 @@
+import os
+import sys
 import pytest
+
+# Ensure the repository root is on the import path so ``bmi`` can be
+# imported when running ``pytest`` directly.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from bmi import calcular_bmi, clasificar_bmi
 


### PR DESCRIPTION
## Summary
- fix import path in `tests/test_bmi.py`
- update README with new test instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684eefed01c083229d6a9c5736bd0ee8