### PR TITLE
Add user selection and history viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This repository contains a simple Python script `bmi.py` that calculates the **B
 
 ## How the script works
 
-Running the script will first ask for your name and then prompt you for your weight in kilograms and height in meters (questions are displayed in Spanish). Values must fall within a sensible range (30–300 kg for weight and 0.5–2.5 m for height). It then computes your BMI, shows the associated classification (e.g. Normal, Alto) and prints a table highlighting your category. Depending on the result, the script also displays a short recommendation. After that the program shows the ideal weight range for the given height and lets you enter a target weight to see its BMI. Each time you complete a calculation the data are stored in a CSV file inside the ``registros`` directory.
+When launched, the program looks for CSV files in the ``registros`` directory and lists the stored user names alphabetically. Selecting a number from this list prints the past BMI history for that user. You can also choose ``0`` to start as a new user.
+
+After the selection phase, the script will prompt for your weight in kilograms and height in meters (questions are displayed in Spanish). Values must fall within a sensible range (30–300 kg for weight and 0.5–2.5 m for height). It then computes your BMI, shows the associated classification (e.g. Normal, Alto) and prints a table highlighting your category. Depending on the result, the script also displays a short recommendation. After that the program shows the ideal weight range for the given height and lets you enter a target weight to see its BMI. Each time you complete a calculation the data are stored in a CSV file inside the ``registros`` directory.
 
 ## Prerequisites
 

--- a/bmi.py
+++ b/bmi.py
@@ -45,6 +45,44 @@ def pedir_cadena_no_vacia(prompt):
             return valor
         print("Por favor ingresa un valor no vacío.")
 
+def obtener_nombres_guardados(base_dir="registros"):
+    """Devuelve una lista de nombres con registros guardados ordenados alfabéticamente."""
+    if not os.path.isdir(base_dir):
+        return []
+    nombres = []
+    for archivo in os.listdir(base_dir):
+        if archivo.lower().endswith(".csv"):
+            nombre = os.path.splitext(archivo)[0].replace("_", " ")
+            nombres.append(nombre)
+    nombres.sort(key=lambda n: n.lower())
+    return nombres
+
+
+def cargar_historial(nombre, base_dir="registros"):
+    """Carga el historial de un usuario y devuelve una lista de registros."""
+    sanitized = "".join(c for c in nombre if c.isalnum() or c in "-_ ").strip().replace(" ", "_")
+    archivo = os.path.join(base_dir, f"{sanitized}.csv")
+    if not os.path.exists(archivo):
+        return []
+    with open(archivo, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def mostrar_historial(nombre, base_dir="registros"):
+    """Muestra por pantalla el historial de un usuario si existe."""
+    registros = cargar_historial(nombre, base_dir)
+    if not registros:
+        print("No hay registros previos.\n")
+        return
+    print(f"Historial para {nombre}:")
+    for reg in registros:
+        fecha = reg.get("fecha", "-")
+        bmi = reg.get("bmi", "-")
+        clasificacion = reg.get("clasificacion", "-")
+        print(f" {fecha} -> BMI {bmi} ({clasificacion})")
+    print()
+
+
 def main():
     """Ejecuta el flujo principal de la aplicación."""
     while True:
@@ -56,7 +94,21 @@ def main():
         print(" CALCULADORA DE BMI ".center(40))
         print("=" * 40)
 
-        nombre = pedir_cadena_no_vacia("¿Cómo te llamas? ")
+        nombres = obtener_nombres_guardados()
+        nombre = None
+        if nombres:
+            print("Usuarios con historial registrado:")
+            for idx, n in enumerate(nombres, 1):
+                print(f" {idx}) {n}")
+            print(" 0) Nuevo usuario")
+            eleccion = input("Selecciona un usuario por número o 0 para nuevo: ")
+            if eleccion.isdigit():
+                idx = int(eleccion)
+                if 1 <= idx <= len(nombres):
+                    nombre = nombres[idx - 1]
+                    mostrar_historial(nombre)
+        if not nombre:
+            nombre = pedir_cadena_no_vacia("¿Cómo te llamas? ")
         print(f"Hola, {nombre}!\n")
 
         # Pedir peso y talla al usuario


### PR DESCRIPTION
## Summary
- on startup list users with stored history from `registros`
- allow selecting a user to display their past BMI records
- document new behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ef397357c8322a654b1333cc8c5c4