### PR TITLE
Add BMI history plotting helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,16 @@ pytest
 
 This project is licensed under the [MIT License](LICENSE).
 
+
+## Plotting BMI history
+
+A helper script ``plot_bmi_history.py`` reads the CSV file for a user and
+plots their BMI values over time using ``matplotlib``. The plot displays the
+evolution and prints whether the trend is ``rising``, ``falling`` or ``stable``
+based on the first and last stored BMI values. Run it with:
+
+```bash
+python plot_bmi_history.py <nombre>
+```
+
+Make sure ``matplotlib`` is installed to view the graph.

--- a/plot_bmi_history.py
+++ b/plot_bmi_history.py
@@ -1,0 +1,49 @@
+import argparse
+import matplotlib.pyplot as plt
+from datetime import datetime
+
+from bmi import cargar_historial
+
+def calcular_tendencia_bmi(registros, threshold=0.1):
+    """Return 'rising', 'falling' or 'stable' depending on BMI trend."""
+    if len(registros) < 2:
+        return "stable"
+    registros_sorted = sorted(registros, key=lambda r: r.get("fecha", ""))
+    primero = float(registros_sorted[0]["bmi"])
+    ultimo = float(registros_sorted[-1]["bmi"])
+    diff = ultimo - primero
+    if diff > threshold:
+        return "rising"
+    elif diff < -threshold:
+        return "falling"
+    return "stable"
+
+def plot_historial(nombre, base_dir="registros"):
+    registros = cargar_historial(nombre, base_dir)
+    if not registros:
+        print(f"No hay historial para {nombre}")
+        return
+    registros_sorted = sorted(registros, key=lambda r: r.get("fecha", ""))
+    fechas = [datetime.fromisoformat(r["fecha"]) for r in registros_sorted]
+    bmis = [float(r["bmi"]) for r in registros_sorted]
+    plt.figure()
+    plt.plot(fechas, bmis, marker="o")
+    plt.xlabel("Fecha")
+    plt.ylabel("BMI")
+    plt.title(f"Evolución del BMI para {nombre}")
+    plt.gcf().autofmt_xdate()
+    tendencia = calcular_tendencia_bmi(registros_sorted)
+    plt.tight_layout()
+    plt.show()
+    print(f"Tendencia para {nombre}: {tendencia}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Grafica el historial de BMI de un usuario")
+    parser.add_argument("nombre", help="Nombre del usuario")
+    parser.add_argument("--base-dir", default="registros", help="Directorio con registros")
+    args = parser.parse_args()
+    plot_historial(args.nombre, args.base_dir)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_trend.py
+++ b/tests/test_trend.py
@@ -1,0 +1,27 @@
+import pytest
+
+from plot_bmi_history import calcular_tendencia_bmi
+
+
+def test_calcular_tendencia_bmi_rising():
+    registros = [
+        {"fecha": "2024-01-01T00:00:00", "bmi": 20},
+        {"fecha": "2024-02-01T00:00:00", "bmi": 21},
+    ]
+    assert calcular_tendencia_bmi(registros) == "rising"
+
+
+def test_calcular_tendencia_bmi_falling():
+    registros = [
+        {"fecha": "2024-01-01T00:00:00", "bmi": 25},
+        {"fecha": "2024-02-01T00:00:00", "bmi": 24},
+    ]
+    assert calcular_tendencia_bmi(registros) == "falling"
+
+
+def test_calcular_tendencia_bmi_stable():
+    registros = [
+        {"fecha": "2024-01-01T00:00:00", "bmi": 22},
+        {"fecha": "2024-02-01T00:00:00", "bmi": 22.05},
+    ]
+    assert calcular_tendencia_bmi(registros) == "stable"


### PR DESCRIPTION
## Summary
- add `plot_bmi_history.py` for visualizing BMI history
- describe new script in README
- test BMI trend calculation

## Testing
- `pip install matplotlib`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684ef4461908832284030b43a7b1f49f