### PR TITLE
Add function to analyze recent BMI records

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ python plot_bmi_history.py <nombre>
 ```
 
 Make sure ``matplotlib`` is installed to view the graph.
+
+## Analyzing recent history
+
+The helper module also provides ``analizar_registros_recientes`` which inspects
+the last few weeks of stored data. It prints whether your BMI is rising,
+falling or stable and reports any change in BMI classification.
+
+Example usage:
+
+```bash
+python -c "import plot_bmi_history as ph; ph.analizar_registros_recientes('Tania')"
+```

--- a/plot_bmi_history.py
+++ b/plot_bmi_history.py
@@ -1,6 +1,6 @@
 import argparse
 import matplotlib.pyplot as plt
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from bmi import cargar_historial
 
@@ -17,6 +17,54 @@ def calcular_tendencia_bmi(registros, threshold=0.1):
     elif diff < -threshold:
         return "falling"
     return "stable"
+
+
+def analizar_registros_recientes(nombre, semanas=4, base_dir="registros"):
+    """Analiza las \u00faltimas ``semanas`` de registros y muestra consejos."""
+    registros = cargar_historial(nombre, base_dir)
+    if not registros:
+        print(f"No hay historial para {nombre}")
+        return
+
+    limite = datetime.now() - timedelta(weeks=semanas)
+    recientes = [
+        r
+        for r in registros
+        if datetime.fromisoformat(r["fecha"]) >= limite
+    ]
+    if len(recientes) < 2:
+        print("No hay suficientes registros recientes para analizar.")
+        return
+
+    recientes_sorted = sorted(recientes, key=lambda r: r.get("fecha", ""))
+    tendencia = calcular_tendencia_bmi(recientes_sorted)
+    primera = recientes_sorted[0]["clasificacion"]
+    ultima = recientes_sorted[-1]["clasificacion"]
+
+    orden = ["Muy bajo", "Bajo", "Normal", "Alto", "Muy alto"]
+    idx_primera = orden.index(primera)
+    idx_ultima = orden.index(ultima)
+
+    if idx_ultima < idx_primera:
+        cambio = f"mejor\u00f3 (de {primera} a {ultima}). \u00a1Buen trabajo!"
+    elif idx_ultima > idx_primera:
+        cambio = (
+            f"empeor\u00f3 (de {primera} a {ultima}). "
+            "Revisa tu alimentaci\u00f3n y actividad f\u00edsica."
+        )
+    else:
+        cambio = f"se mantiene en {ultima}."
+
+    if tendencia == "rising":
+        tendencia_msg = "tu BMI est\u00e1 subiendo"
+    elif tendencia == "falling":
+        tendencia_msg = "tu BMI est\u00e1 bajando"
+    else:
+        tendencia_msg = "tu BMI se mantiene estable"
+
+    print(
+        f"En las \u00faltimas {semanas} semanas {tendencia_msg} y tu clasificaci\u00f3n {cambio}"
+    )
 
 def plot_historial(nombre, base_dir="registros"):
     registros = cargar_historial(nombre, base_dir)

--- a/tests/test_recent.py
+++ b/tests/test_recent.py
@@ -1,0 +1,45 @@
+import pytest
+from datetime import datetime
+import plot_bmi_history as ph
+
+analizar_registros_recientes = ph.analizar_registros_recientes
+
+
+def test_analizar_recientes_mejora(capsys, monkeypatch):
+    registros = [
+        {"fecha": "2024-01-01T00:00:00", "bmi": 31, "clasificacion": "Muy alto"},
+        {"fecha": "2024-01-15T00:00:00", "bmi": 29, "clasificacion": "Alto"},
+    ]
+    monkeypatch.setattr(
+        "plot_bmi_history.cargar_historial",
+        lambda nombre, base_dir="registros": registros,
+    )
+    class DummyDate(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2024, 2, 1)
+
+    monkeypatch.setattr(ph, "datetime", DummyDate)
+    analizar_registros_recientes("Ana", semanas=8)
+    out = capsys.readouterr().out
+    assert "mejor\u00f3" in out
+
+
+def test_analizar_recientes_empeora(capsys, monkeypatch):
+    registros = [
+        {"fecha": "2024-01-01T00:00:00", "bmi": 22, "clasificacion": "Normal"},
+        {"fecha": "2024-02-01T00:00:00", "bmi": 27, "clasificacion": "Alto"},
+    ]
+    monkeypatch.setattr(
+        "plot_bmi_history.cargar_historial",
+        lambda nombre, base_dir="registros": registros,
+    )
+    class DummyDate(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2024, 2, 2)
+
+    monkeypatch.setattr(ph, "datetime", DummyDate)
+    analizar_registros_recientes("Ana", semanas=8)
+    out = capsys.readouterr().out
+    assert "empeor\u00f3" in out


### PR DESCRIPTION
## Summary
- implement `analizar_registros_recientes` to summarize recent BMI trend and classification changes
- document recent analysis feature in README
- add tests covering recent record analysis

## Testing
- `pip install matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ef522214c8322bc2ea9c9e554a48c