### PR TITLE
Add tests for stored history and trend threshold

### DIFF
--- a/tests/test_storage_and_names.py
+++ b/tests/test_storage_and_names.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import csv
+import pytest
+
+# Ensure repository root in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from bmi import (
+    obtener_nombres_guardados,
+    guardar_registro,
+    cargar_historial,
+    mostrar_historial,
+    calcular_rango_peso_saludable,
+)
+
+
+def test_obtener_nombres_guardados(tmp_path):
+    base = tmp_path
+    (base / "juan.csv").write_text("header\n", encoding="utf-8")
+    (base / "Ana_Maria.csv").write_text("header\n", encoding="utf-8")
+    (base / "otro.txt").write_text("ignored", encoding="utf-8")
+    nombres = obtener_nombres_guardados(str(base))
+    assert nombres == ["Ana Maria", "juan"]
+
+
+def test_guardar_y_cargar_registro(tmp_path):
+    base = tmp_path
+    guardar_registro("Ana Maria", 70, 1.75, 22.86, "Normal", base_dir=str(base))
+    archivo = base / "Ana_Maria.csv"
+    assert archivo.exists()
+    registros = cargar_historial("Ana Maria", str(base))
+    assert len(registros) == 1
+    r = registros[0]
+    assert r["nombre"] == "Ana Maria"
+    assert float(r["peso"]) == pytest.approx(70)
+    assert float(r["altura"]) == pytest.approx(1.75)
+    assert float(r["bmi"]) == pytest.approx(22.86, rel=1e-2)
+    assert r["clasificacion"] == "Normal"
+
+
+def test_mostrar_historial(capsys, tmp_path):
+    base = tmp_path
+    guardar_registro("Jose", 80, 1.8, 24.69, "Normal", base_dir=str(base))
+    mostrar_historial("Jose", str(base))
+    out = capsys.readouterr().out
+    assert "Historial para Jose" in out
+    assert "Normal" in out
+
+
+def test_calcular_rango_peso_saludable_custom():
+    peso_min, peso_max = calcular_rango_peso_saludable(1.8, bmi_min=20, bmi_max=22)
+    assert peso_min == pytest.approx(20 * 1.8 ** 2)
+    assert peso_max == pytest.approx(22 * 1.8 ** 2)

--- a/tests/test_trend.py
+++ b/tests/test_trend.py
@@ -25,3 +25,12 @@ def test_calcular_tendencia_bmi_stable():
         {"fecha": "2024-02-01T00:00:00", "bmi": 22.05},
     ]
     assert calcular_tendencia_bmi(registros) == "stable"
+
+
+def test_calcular_tendencia_bmi_threshold_param():
+    registros = [
+        {"fecha": "2024-01-01T00:00:00", "bmi": 22},
+        {"fecha": "2024-02-01T00:00:00", "bmi": 22.05},
+    ]
+    assert calcular_tendencia_bmi(registros, threshold=0.1) == "stable"
+    assert calcular_tendencia_bmi(registros, threshold=0.04) == "rising"


### PR DESCRIPTION
## Summary
- cover user history helpers like `obtener_nombres_guardados` and `guardar_registro`
- test `mostrar_historial` printing
- verify custom limits for `calcular_rango_peso_saludable`
- test trend detection with different threshold

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ef77547e88322b5e3335f1bbec86e