### PR TITLE
Add integration tests and plot trend checks

### DIFF
--- a/tests/test_main_integration.py
+++ b/tests/test_main_integration.py
@@ -1,0 +1,44 @@
+import bmi
+
+
+def _patch_base_dir(monkeypatch, tmp_path):
+    orig_guardar = bmi.guardar_registro
+    orig_cargar = bmi.cargar_historial
+    orig_obtener = bmi.obtener_nombres_guardados
+    monkeypatch.setattr(
+        bmi,
+        "guardar_registro",
+        lambda n, p, a, b, c, base_dir="registros": orig_guardar(
+            n, p, a, b, c, base_dir=str(tmp_path)
+        ),
+    )
+    monkeypatch.setattr(
+        bmi,
+        "cargar_historial",
+        lambda n, base_dir="registros": orig_cargar(n, str(tmp_path))
+    )
+    monkeypatch.setattr(
+        bmi,
+        "obtener_nombres_guardados",
+        lambda base_dir="registros": orig_obtener(str(tmp_path))
+    )
+    monkeypatch.setattr(bmi, "limpiar_pantalla", lambda: None)
+    monkeypatch.setattr(bmi, "imprimir_tabla_bmi", lambda *a, **k: None)
+
+
+
+def test_main_creates_and_loads_records(tmp_path, monkeypatch, capsys):
+    _patch_base_dir(monkeypatch, tmp_path)
+    # First run as new user
+    inputs = iter(["Ana", "70", "1.75", "65", "n"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    bmi.main()
+    registros = bmi.cargar_historial("Ana")
+    assert len(registros) == 1
+
+    # Second run selecting existing user
+    inputs2 = iter(["1", "71", "1.75", "65", "n"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs2))
+    bmi.main()
+    out = capsys.readouterr().out
+    assert "Historial para Ana" in out

--- a/tests/test_plot_history.py
+++ b/tests/test_plot_history.py
@@ -1,0 +1,40 @@
+import csv
+import matplotlib.pyplot as plt
+import plot_bmi_history as ph
+
+
+def _write_records(path, bmis):
+    with open(path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["fecha", "nombre", "peso", "altura", "bmi", "clasificacion"],
+        )
+        writer.writeheader()
+        for i, bmi in enumerate(bmis):
+            writer.writerow(
+                {
+                    "fecha": f"2024-{i+1:02d}-01T00:00:00",
+                    "nombre": "Ana",
+                    "peso": "70",
+                    "altura": "1.70",
+                    "bmi": bmi,
+                    "clasificacion": "Normal",
+                }
+            )
+
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "bmis, expected",
+    [([20, 21], "rising"), ([25, 24], "falling"), ([22, 22.05], "stable")],
+)
+def test_plot_historial_trend(tmp_path, monkeypatch, capsys, bmis, expected):
+    csv_path = tmp_path / "Ana.csv"
+    _write_records(csv_path, bmis)
+    monkeypatch.setattr(plt, "show", lambda: None)
+    ph.plot_historial("Ana", str(tmp_path))
+    out = capsys.readouterr().out
+    assert f"Tendencia para Ana: {expected}" in out
+


### PR DESCRIPTION
## Summary
- add tests for `plot_historial` using temp dirs and capturing trend output
- add integration test for `bmi.main` covering saving and loading
- increase coverage to ~79%

## Testing
- `pytest --cov=bmi --cov=plot_bmi_history`

------
https://chatgpt.com/codex/tasks/task_b_684f0235aec88322a4e3a5072e54a081