### PR TITLE
Add optional language flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ scripts in this repository.
 ## Usage
 
 From the repository root, execute the ``bmi`` command (installed via
-``pip install .``):
+``pip install .``).  A ``--lang`` flag lets you switch between
+Spanish (default) and English:
 
 ```bash
-bmi
+bmi --lang en
 ```
 
 After entering your name, weight and height you should see output similar to:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.scripts]
-bmi = "bmi:main"
+bmi = "bmi:main_cli"
 plot-bmi-history = "plot_bmi_history:main"
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- allow selecting interface language with `--lang`
- add main_cli helper for console entry point
- document new flag in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f05069de48322acc55a0f47058456