### PR TITLE
Add base directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ scripts in this repository.
 
 From the repository root, execute the ``bmi`` command (installed via
 ``pip install .``).  A ``--lang`` flag lets you switch between
-Spanish (default) and English:
+Spanish (default) and English. Use ``--base-dir`` to select where CSV
+records are stored (default is ``registros``):
 
 ```bash
 bmi --lang en
@@ -58,7 +59,7 @@ El BMI para 65 kg sería: 21.25
 
 (The highlighted cell uses inverted colours.)
 
-All completed calculations are appended to ``registros/<tu_nombre>.csv`` so you can keep track of your history.
+All completed calculations are appended to ``registros/<tu_nombre>.csv`` so you can keep track of your history. The directory can be changed with the ``--base-dir`` flag.
 
 ## Running tests
 

--- a/bmi.py
+++ b/bmi.py
@@ -169,6 +169,11 @@ def main(argv=None):
         choices=MENSAJES.keys(),
         help="Selecciona el idioma de la interfaz",
     )
+    parser.add_argument(
+        "--base-dir",
+        default="registros",
+        help="Directorio base para guardar registros",
+    )
     args = parser.parse_args(argv)
     establecer_idioma(args.lang)
 
@@ -181,7 +186,7 @@ def main(argv=None):
         print(msj("titulo").center(40))
         print("=" * 40)
 
-        nombres = obtener_nombres_guardados()
+        nombres = obtener_nombres_guardados(args.base_dir)
         nombre = None
         if nombres:
             print(msj("lista_usuarios"))
@@ -193,7 +198,7 @@ def main(argv=None):
                 idx = int(eleccion)
                 if 1 <= idx <= len(nombres):
                     nombre = nombres[idx - 1]
-                    mostrar_historial(nombre)
+                    mostrar_historial(nombre, args.base_dir)
         if not nombre:
             nombre = pedir_cadena_no_vacia(msj("pregunta_nombre"))
         print(msj("saludo", nombre=nombre))
@@ -229,7 +234,14 @@ def main(argv=None):
         bmi_objetivo = calcular_bmi(peso_objetivo, altura)
         print(msj("bmi_objetivo", peso_objetivo=peso_objetivo, bmi_objetivo=bmi_objetivo))
 
-        guardar_registro(nombre, peso, altura, bmi, clasificacion)
+        guardar_registro(
+            nombre,
+            peso,
+            altura,
+            bmi,
+            clasificacion,
+            args.base_dir,
+        )
 
         repetir = input(msj("repetir"))
         if repetir.strip().lower().startswith("n"):

--- a/tests/test_main_integration.py
+++ b/tests/test_main_integration.py
@@ -1,44 +1,23 @@
 import bmi
 
 
-def _patch_base_dir(monkeypatch, tmp_path):
-    orig_guardar = bmi.guardar_registro
-    orig_cargar = bmi.cargar_historial
-    orig_obtener = bmi.obtener_nombres_guardados
-    monkeypatch.setattr(
-        bmi,
-        "guardar_registro",
-        lambda n, p, a, b, c, base_dir="registros": orig_guardar(
-            n, p, a, b, c, base_dir=str(tmp_path)
-        ),
-    )
-    monkeypatch.setattr(
-        bmi,
-        "cargar_historial",
-        lambda n, base_dir="registros": orig_cargar(n, str(tmp_path))
-    )
-    monkeypatch.setattr(
-        bmi,
-        "obtener_nombres_guardados",
-        lambda base_dir="registros": orig_obtener(str(tmp_path))
-    )
+def _patch_ui(monkeypatch):
     monkeypatch.setattr(bmi, "limpiar_pantalla", lambda: None)
     monkeypatch.setattr(bmi, "imprimir_tabla_bmi", lambda *a, **k: None)
 
 
-
 def test_main_creates_and_loads_records(tmp_path, monkeypatch, capsys):
-    _patch_base_dir(monkeypatch, tmp_path)
+    _patch_ui(monkeypatch)
     # First run as new user
     inputs = iter(["Ana", "70", "1.75", "65", "n"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
-    bmi.main()
-    registros = bmi.cargar_historial("Ana")
+    bmi.main(["--base-dir", str(tmp_path)])
+    registros = bmi.cargar_historial("Ana", str(tmp_path))
     assert len(registros) == 1
 
     # Second run selecting existing user
     inputs2 = iter(["1", "71", "1.75", "65", "n"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs2))
-    bmi.main()
+    bmi.main(["--base-dir", str(tmp_path)])
     out = capsys.readouterr().out
     assert "Historial para Ana" in out


### PR DESCRIPTION
## Summary
- add `--base-dir` option to choose directory for records
- use the option throughout `bmi.main`
- adjust integration test to pass directory via CLI
- document the flag in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f127a77a48322be475e17ecbd75d3