### PR TITLE
Add language support to plot history

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ based on the first and last stored BMI values. Run it with:
 ```bash
 plot-bmi-history <nombre>
 ```
+You can add ``--lang en`` to show the output in English.
 
 Make sure ``matplotlib`` is installed to view the graph.
 

--- a/tests/test_plot_history.py
+++ b/tests/test_plot_history.py
@@ -38,3 +38,13 @@ def test_plot_historial_trend(tmp_path, monkeypatch, capsys, bmis, expected):
     out = capsys.readouterr().out
     assert f"Tendencia para Ana: {expected}" in out
 
+
+def test_main_lang_en(tmp_path, monkeypatch, capsys):
+    csv_path = tmp_path / "Ana.csv"
+    _write_records(csv_path, [20, 21])
+    monkeypatch.setattr(plt, "show", lambda: None)
+    ph.main(["Ana", "--base-dir", str(tmp_path), "--lang", "en"])
+    out = capsys.readouterr().out
+    assert "Trend for Ana: rising" in out
+    ph.establecer_idioma("es")
+


### PR DESCRIPTION
## Summary
- add a minimal translation table and language utilities in `plot_bmi_history`
- implement `--lang` option for the history plot script
- show translated trend and error messages
- extend tests to cover the new option
- document `--lang` flag in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f1793946483228c6b26aa936568f5