### PR TITLE
Add imprimir_tabla_bmi table output test

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,0 +1,15 @@
+import bmi
+
+
+def test_imprimir_tabla_bmi_output(capsys):
+    bmi.imprimir_tabla_bmi(22.86, "Normal")
+    out = capsys.readouterr().out
+    lines = out.splitlines()
+    width = 12
+    expected_line = "+" + "+".join(["-" * width for _ in range(5)]) + "+"
+    assert lines[0] == expected_line
+    assert lines[2] == expected_line
+    assert lines[4] == expected_line
+    highlight = f"\x1b[7m{format(22.86, '.2f').center(width)}\x1b[0m"
+    cells = lines[3].split("|")
+    assert cells[3] == highlight


### PR DESCRIPTION
## Summary
- add tests for table printing with ANSI highlight

## Testing
- `pip install matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f19ec6eb48322be2176de5b38174d