### PR TITLE
Add English error messages and tests

### DIFF
--- a/bmi.py
+++ b/bmi.py
@@ -26,6 +26,11 @@ MENSAJES = {
         "pregunta_objetivo": "Ingresa un peso objetivo para ver su BMI: ",
         "bmi_objetivo": "El BMI para {peso_objetivo} kg sería: {bmi_objetivo:.2f}",
         "repetir": "¿Deseas calcular otro BMI? [S/N]: ",
+        "error_positivo": "Por favor ingresa un número positivo mayor que cero.",
+        "error_minimo": "El valor debe ser mayor o igual que {min_val}.",
+        "error_maximo": "El valor debe ser menor o igual que {max_val}.",
+        "error_invalido": "Entrada inválida. Ingresa un número válido.",
+        "error_vacio": "Por favor ingresa un valor no vacío.",
     },
     "en": {
         "titulo": "BMI CALCULATOR",
@@ -47,6 +52,11 @@ MENSAJES = {
         "pregunta_objetivo": "Enter a target weight to see its BMI: ",
         "bmi_objetivo": "The BMI for {peso_objetivo} kg would be: {bmi_objetivo:.2f}",
         "repetir": "Calculate another BMI? [Y/N]: ",
+        "error_positivo": "Please enter a positive number greater than zero.",
+        "error_minimo": "Value must be greater than or equal to {min_val}.",
+        "error_maximo": "Value must be less than or equal to {max_val}.",
+        "error_invalido": "Invalid input. Enter a valid number.",
+        "error_vacio": "Please enter a non-empty value.",
     },
 }
 
@@ -91,17 +101,17 @@ def pedir_float_positivo(prompt, min_val=None, max_val=None):
         try:
             valor = float(dato)
             if valor <= 0:
-                print("Por favor ingresa un número positivo mayor que cero.")
+                print(msj("error_positivo"))
                 continue
             if min_val is not None and valor < min_val:
-                print(f"El valor debe ser mayor o igual que {min_val}.")
+                print(msj("error_minimo", min_val=min_val))
                 continue
             if max_val is not None and valor > max_val:
-                print(f"El valor debe ser menor o igual que {max_val}.")
+                print(msj("error_maximo", max_val=max_val))
                 continue
             return valor
         except ValueError:
-            print("Entrada inválida. Ingresa un número válido.")
+            print(msj("error_invalido"))
 
 
 def pedir_cadena_no_vacia(prompt):
@@ -110,7 +120,7 @@ def pedir_cadena_no_vacia(prompt):
         valor = input(prompt).strip()
         if valor:
             return valor
-        print("Por favor ingresa un valor no vacío.")
+        print(msj("error_vacio"))
 
 
 def obtener_nombres_guardados(base_dir="registros"):

--- a/tests/test_main_integration.py
+++ b/tests/test_main_integration.py
@@ -21,3 +21,35 @@ def test_main_creates_and_loads_records(tmp_path, monkeypatch, capsys):
     bmi.main(["--base-dir", str(tmp_path)])
     out = capsys.readouterr().out
     assert "Historial para Ana" in out
+
+
+def test_main_lang_en_errors(tmp_path, monkeypatch, capsys):
+    _patch_ui(monkeypatch)
+    inputs = iter([
+        "",
+        " ",
+        "Bob",
+        "-1",
+        "20",
+        "301",
+        "abc",
+        "70",
+        "0",
+        "0.4",
+        "2.6",
+        "no",
+        "1.7",
+        "65",
+        "n",
+    ])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    bmi.main(["--base-dir", str(tmp_path), "--lang", "en"])
+    out = capsys.readouterr().out
+    assert "Please enter a non-empty value." in out
+    assert "Please enter a positive number greater than zero." in out
+    assert "Value must be greater than or equal to 30." in out
+    assert "Value must be less than or equal to 300." in out
+    assert "Value must be greater than or equal to 0.5." in out
+    assert "Value must be less than or equal to 2.5." in out
+    assert "Invalid input. Enter a valid number." in out
+    bmi.establecer_idioma("es")


### PR DESCRIPTION
## Summary
- extend `MENSAJES` with English versions of error prompts
- show error prompts with `msj()` in `pedir_float_positivo` and `pedir_cadena_no_vacia`
- test that running the app with `--lang en` prints the English error prompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f1d7ea2688322a693c767794e433b