### PR TITLE
Add BMI category translations

### DIFF
--- a/bmi.py
+++ b/bmi.py
@@ -30,7 +30,18 @@ MENSAJES = {
         "error_minimo": "El valor debe ser mayor o igual que {min_val}.",
         "error_maximo": "El valor debe ser menor o igual que {max_val}.",
         "error_invalido": "Entrada inválida. Ingresa un número válido.",
-        "error_vacio": "Por favor ingresa un valor no vacío.",
+    "error_vacio": "Por favor ingresa un valor no vacío.",
+        # Categorías y consejos
+        "cat_muy_bajo": "Muy bajo",
+        "cat_bajo": "Bajo",
+        "cat_normal": "Normal",
+        "cat_alto": "Alto",
+        "cat_muy_alto": "Muy alto",
+        "adv_muy_bajo": "Consulta a un profesional para mejorar tu nutrición.",
+        "adv_bajo": "Incluye más calorías saludables en tu dieta.",
+        "adv_normal": "Continúa con tu estilo de vida saludable.",
+        "adv_alto": "Aumenta la actividad física y cuida tu alimentación.",
+        "adv_muy_alto": "Busca apoyo médico para reducir tu peso.",
     },
     "en": {
         "titulo": "BMI CALCULATOR",
@@ -57,10 +68,28 @@ MENSAJES = {
         "error_maximo": "Value must be less than or equal to {max_val}.",
         "error_invalido": "Invalid input. Enter a valid number.",
         "error_vacio": "Please enter a non-empty value.",
+        # Categories and advice
+        "cat_muy_bajo": "Very low",
+        "cat_bajo": "Low",
+        "cat_normal": "Normal",
+        "cat_alto": "High",
+        "cat_muy_alto": "Very high",
+        "adv_muy_bajo": "Consult a professional to improve your nutrition.",
+        "adv_bajo": "Include more healthy calories in your diet.",
+        "adv_normal": "Keep up your healthy lifestyle.",
+        "adv_alto": "Increase physical activity and watch your diet.",
+        "adv_muy_alto": "Seek medical support to reduce your weight.",
     },
 }
 
 _IDIOMA = "es"
+
+# Classification constants
+CAT_MUY_BAJO = "muy_bajo"
+CAT_BAJO = "bajo"
+CAT_NORMAL = "normal"
+CAT_ALTO = "alto"
+CAT_MUY_ALTO = "muy_alto"
 
 
 def establecer_idioma(idioma):
@@ -169,6 +198,8 @@ def mostrar_historial(nombre, base_dir="registros"):
         fecha = reg.get("fecha", "-")
         bmi = reg.get("bmi", "-")
         clasificacion = reg.get("clasificacion", "-")
+        if clasificacion != "-":
+            clasificacion = msj("cat_" + clasificacion)
         print(f" {fecha} -> BMI {bmi} ({clasificacion})")
     print()
 
@@ -234,10 +265,11 @@ def main(argv=None):
         bmi = calcular_bmi(peso, altura)
         print(msj("tu_bmi", bmi=bmi))
         clasificacion = clasificar_bmi(bmi)
-        print(msj("clasificacion", clasificacion=clasificacion))
-        consejo = obtener_consejo(clasificacion)
-        if consejo:
-            print(consejo)
+        clasificacion_label = msj("cat_" + clasificacion)
+        print(msj("clasificacion", clasificacion=clasificacion_label))
+        consejo_key = obtener_consejo(clasificacion)
+        if consejo_key:
+            print(msj(consejo_key))
         imprimir_tabla_bmi(bmi, clasificacion)
 
         peso_min, peso_max = calcular_rango_peso_saludable(altura)
@@ -271,41 +303,43 @@ def calcular_bmi(peso, altura):
 
 
 def clasificar_bmi(bmi):
-    """Devuelve una clasificaci\u00f3n textual seg\u00fan el BMI."""
+    """Devuelve una clave de clasificaci\u00f3n seg\u00fan el BMI."""
     if bmi < 16:
-        return "Muy bajo"
+        return CAT_MUY_BAJO
     elif bmi < 18.5:
-        return "Bajo"
+        return CAT_BAJO
     elif bmi < 25:
-        return "Normal"
+        return CAT_NORMAL
     elif bmi < 30:
-        return "Alto"
+        return CAT_ALTO
     else:
-        return "Muy alto"
+        return CAT_MUY_ALTO
 
 
 def obtener_consejo(clasificacion):
-    """Devuelve un breve consejo seg\u00fan la clasificaci\u00f3n del BMI."""
+    """Devuelve la clave del consejo seg\u00fan la clasificaci\u00f3n del BMI."""
     mensajes = {
-        "Muy bajo": (
-            "Consulta a un profesional para mejorar tu nutrición."
-        ),
-        "Bajo": "Incluye más calorías saludables en tu dieta.",
-        "Normal": "Continúa con tu estilo de vida saludable.",
-        "Alto": (
-            "Aumenta la actividad física y cuida tu alimentación."
-        ),
-        "Muy alto": "Busca apoyo médico para reducir tu peso.",
+        CAT_MUY_BAJO: "adv_muy_bajo",
+        CAT_BAJO: "adv_bajo",
+        CAT_NORMAL: "adv_normal",
+        CAT_ALTO: "adv_alto",
+        CAT_MUY_ALTO: "adv_muy_alto",
     }
     return mensajes.get(clasificacion, "")
 
 
 def imprimir_tabla_bmi(bmi, clasificacion):
     """Muestra una tabla con el BMI dentro del rango destacado."""
-    categorias = ["Muy bajo", "Bajo", "Normal", "Alto", "Muy alto"]
+    categorias = [
+        CAT_MUY_BAJO,
+        CAT_BAJO,
+        CAT_NORMAL,
+        CAT_ALTO,
+        CAT_MUY_ALTO,
+    ]
     ancho = 12
     linea = "+" + "+".join(["-" * ancho for _ in categorias]) + "+"
-    encabezado = "|" + "|".join(cat.center(ancho) for cat in categorias) + "|"
+    encabezado = "|" + "|".join(msj("cat_" + cat).center(ancho) for cat in categorias) + "|"
 
     # Construir fila con el BMI en la categor\u00eda correspondiente
     fila = []

--- a/plot_bmi_history.py
+++ b/plot_bmi_history.py
@@ -2,7 +2,14 @@ import argparse
 import matplotlib.pyplot as plt
 from datetime import datetime, timedelta
 
-from bmi import cargar_historial
+from bmi import (
+    cargar_historial,
+    CAT_MUY_BAJO,
+    CAT_BAJO,
+    CAT_NORMAL,
+    CAT_ALTO,
+    CAT_MUY_ALTO,
+)
 
 
 MENSAJES = {
@@ -23,6 +30,11 @@ MENSAJES = {
             "Revisa tu alimentaci\u00f3n y actividad f\u00edsica."
         ),
         "sin_cambio": "se mantiene en {ultima}.",
+        "cat_muy_bajo": "Muy bajo",
+        "cat_bajo": "Bajo",
+        "cat_normal": "Normal",
+        "cat_alto": "Alto",
+        "cat_muy_alto": "Muy alto",
     },
     "en": {
         "no_historial": "No history for {nombre}",
@@ -41,6 +53,11 @@ MENSAJES = {
             "Check your diet and exercise."
         ),
         "sin_cambio": "remains {ultima}.",
+        "cat_muy_bajo": "Very low",
+        "cat_bajo": "Low",
+        "cat_normal": "Normal",
+        "cat_alto": "High",
+        "cat_muy_alto": "Very high",
     },
 }
 
@@ -94,16 +111,19 @@ def analizar_registros_recientes(nombre, semanas=4, base_dir="registros"):
     primera = recientes_sorted[0]["clasificacion"]
     ultima = recientes_sorted[-1]["clasificacion"]
 
-    orden = ["Muy bajo", "Bajo", "Normal", "Alto", "Muy alto"]
+    orden = [CAT_MUY_BAJO, CAT_BAJO, CAT_NORMAL, CAT_ALTO, CAT_MUY_ALTO]
     idx_primera = orden.index(primera)
     idx_ultima = orden.index(ultima)
 
+    primera_label = msj("cat_" + primera)
+    ultima_label = msj("cat_" + ultima)
+
     if idx_ultima < idx_primera:
-        cambio = msj("mejora", primera=primera, ultima=ultima)
+        cambio = msj("mejora", primera=primera_label, ultima=ultima_label)
     elif idx_ultima > idx_primera:
-        cambio = msj("empeora", primera=primera, ultima=ultima)
+        cambio = msj("empeora", primera=primera_label, ultima=ultima_label)
     else:
-        cambio = msj("sin_cambio", ultima=ultima)
+        cambio = msj("sin_cambio", ultima=ultima_label)
 
     if tendencia == "rising":
         tendencia_msg = msj("rising")

--- a/tests/test_bmi.py
+++ b/tests/test_bmi.py
@@ -5,6 +5,11 @@ from bmi import (
     clasificar_bmi,
     pedir_cadena_no_vacia,
     calcular_rango_peso_saludable,
+    CAT_MUY_BAJO,
+    CAT_BAJO,
+    CAT_NORMAL,
+    CAT_ALTO,
+    CAT_MUY_ALTO,
 )
 
 
@@ -16,14 +21,14 @@ def test_calcular_bmi_known_values():
 @pytest.mark.parametrize(
     "bmi_value, expected",
     [
-        (15.9, "Muy bajo"),
-        (16, "Bajo"),
-        (18.4, "Bajo"),
-        (18.5, "Normal"),
-        (24.9, "Normal"),
-        (25, "Alto"),
-        (29.9, "Alto"),
-        (30, "Muy alto"),
+        (15.9, CAT_MUY_BAJO),
+        (16, CAT_BAJO),
+        (18.4, CAT_BAJO),
+        (18.5, CAT_NORMAL),
+        (24.9, CAT_NORMAL),
+        (25, CAT_ALTO),
+        (29.9, CAT_ALTO),
+        (30, CAT_MUY_ALTO),
     ],
 )
 def test_clasificar_bmi_boundaries(bmi_value, expected):

--- a/tests/test_plot_history.py
+++ b/tests/test_plot_history.py
@@ -1,6 +1,7 @@
 import csv
 import matplotlib.pyplot as plt
 import plot_bmi_history as ph
+import bmi
 
 
 def _write_records(path, bmis):
@@ -10,15 +11,15 @@ def _write_records(path, bmis):
             fieldnames=["fecha", "nombre", "peso", "altura", "bmi", "clasificacion"],
         )
         writer.writeheader()
-        for i, bmi in enumerate(bmis):
+        for i, bmi_val in enumerate(bmis):
             writer.writerow(
                 {
                     "fecha": f"2024-{i+1:02d}-01T00:00:00",
                     "nombre": "Ana",
                     "peso": "70",
                     "altura": "1.70",
-                    "bmi": bmi,
-                    "clasificacion": "Normal",
+                    "bmi": bmi_val,
+                    "clasificacion": bmi.CAT_NORMAL,
                 }
             )
 

--- a/tests/test_recent.py
+++ b/tests/test_recent.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import plot_bmi_history as ph
+import bmi
 
 analizar_registros_recientes = ph.analizar_registros_recientes
 
@@ -9,12 +10,12 @@ def test_analizar_recientes_mejora(capsys, monkeypatch):
         {
             "fecha": "2024-01-01T00:00:00",
             "bmi": 31,
-            "clasificacion": "Muy alto",
+            "clasificacion": bmi.CAT_MUY_ALTO,
         },
         {
             "fecha": "2024-01-15T00:00:00",
             "bmi": 29,
-            "clasificacion": "Alto",
+            "clasificacion": bmi.CAT_ALTO,
         },
     ]
     monkeypatch.setattr(
@@ -38,12 +39,12 @@ def test_analizar_recientes_empeora(capsys, monkeypatch):
         {
             "fecha": "2024-01-01T00:00:00",
             "bmi": 22,
-            "clasificacion": "Normal",
+            "clasificacion": bmi.CAT_NORMAL,
         },
         {
             "fecha": "2024-02-01T00:00:00",
             "bmi": 27,
-            "clasificacion": "Alto",
+            "clasificacion": bmi.CAT_ALTO,
         },
     ]
     monkeypatch.setattr(

--- a/tests/test_storage_and_names.py
+++ b/tests/test_storage_and_names.py
@@ -8,6 +8,7 @@ from bmi import (
     mostrar_historial,
     calcular_rango_peso_saludable,
     sanitize_nombre,
+    CAT_NORMAL,
 )
 
 
@@ -27,7 +28,7 @@ def test_guardar_y_cargar_registro(tmp_path):
         70,
         1.75,
         22.86,
-        "Normal",
+        CAT_NORMAL,
         base_dir=str(base),
     )
     archivo = base / "Ana_Maria.csv"
@@ -39,7 +40,7 @@ def test_guardar_y_cargar_registro(tmp_path):
     assert float(r["peso"]) == pytest.approx(70)
     assert float(r["altura"]) == pytest.approx(1.75)
     assert float(r["bmi"]) == pytest.approx(22.86, rel=1e-2)
-    assert r["clasificacion"] == "Normal"
+    assert r["clasificacion"] == CAT_NORMAL
 
 
 def test_mostrar_historial(capsys, tmp_path):
@@ -49,7 +50,7 @@ def test_mostrar_historial(capsys, tmp_path):
         80,
         1.8,
         24.69,
-        "Normal",
+        CAT_NORMAL,
         base_dir=str(base),
     )
     mostrar_historial("Jose", str(base))
@@ -79,7 +80,7 @@ def test_sanitization_consistency(tmp_path, monkeypatch):
 
     monkeypatch.setattr(bmi.os.path, "join", spy_join)
 
-    guardar_registro(nombre, 70, 1.75, 22.86, "Normal", base_dir=str(tmp_path))
+    guardar_registro(nombre, 70, 1.75, 22.86, CAT_NORMAL, base_dir=str(tmp_path))
     cargar_historial(nombre, str(tmp_path))
 
     assert join_calls == [f"{expected}.csv", f"{expected}.csv"]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2,7 +2,7 @@ import bmi
 
 
 def test_imprimir_tabla_bmi_output(capsys):
-    bmi.imprimir_tabla_bmi(22.86, "Normal")
+    bmi.imprimir_tabla_bmi(22.86, bmi.CAT_NORMAL)
     out = capsys.readouterr().out
     lines = out.splitlines()
     width = 12


### PR DESCRIPTION
## Summary
- translate BMI categories and advice messages
- return classification keys from `clasificar_bmi`
- lookup localized labels and advice via `msj`
- adjust history plotting to work with category keys
- update tests for new constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f2f10770883228a7f84e7a955b145