### PR TITLE
Add tests for empty and single recent record cases

### DIFF
--- a/tests/test_recent.py
+++ b/tests/test_recent.py
@@ -61,3 +61,44 @@ def test_analizar_recientes_empeora(capsys, monkeypatch):
     analizar_registros_recientes("Ana", semanas=8)
     out = capsys.readouterr().out
     assert "empeor\u00f3" in out
+
+
+def test_analizar_recientes_sin_historial(capsys, monkeypatch):
+    monkeypatch.setattr(
+        "plot_bmi_history.cargar_historial",
+        lambda nombre, base_dir="registros": [],
+    )
+
+    class DummyDate(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2024, 2, 1)
+
+    monkeypatch.setattr(ph, "datetime", DummyDate)
+    analizar_registros_recientes("Ana", semanas=8)
+    out = capsys.readouterr().out
+    assert "No hay historial" in out
+
+
+def test_analizar_recientes_no_suficientes(capsys, monkeypatch):
+    registros = [
+        {
+            "fecha": "2024-01-01T00:00:00",
+            "bmi": 31,
+            "clasificacion": bmi.CAT_MUY_ALTO,
+        },
+    ]
+    monkeypatch.setattr(
+        "plot_bmi_history.cargar_historial",
+        lambda nombre, base_dir="registros": registros,
+    )
+
+    class DummyDate(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2024, 2, 1)
+
+    monkeypatch.setattr(ph, "datetime", DummyDate)
+    analizar_registros_recientes("Ana", semanas=8)
+    out = capsys.readouterr().out
+    assert "No hay suficientes registros" in out


### PR DESCRIPTION
## Summary
- test no history path in recent analysis
- test only one recent record path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f385deaf48322859235006653f781