### PR TITLE
Move matplotlib to optional plot extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install .[plot]
           pip install flake8 pytest
       - name: Run flake8
         run: flake8

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ After the selection phase, the script will prompt for your weight in kilograms a
 ## Prerequisites
 
 - Python 3.6 or later (the script was tested with Python 3.12)
-- Dependencies are listed in ``pyproject.toml``. Install them together with
-  the package using ``pip install .`` or, if running straight from the source,
-  with ``pip install -r requirements.txt``.
+ - Dependencies are listed in ``pyproject.toml``. Install them with
+   ``pip install .``.  If you want the optional plotting helper make sure to add
+   the ``plot`` extra:
+   ``pip install .[plot]``.  When running straight from the source you can use
+   ``pip install -r requirements.txt`` which already includes this extra.
 
 ## Installation
 
@@ -24,6 +26,8 @@ console scripts are available in your environment:
 
 ```bash
 pip install .
+# install the optional plotting helper with:
+pip install .[plot]
 ```
 
 This will provide the commands ``bmi`` and ``plot-bmi-history`` which wrap the
@@ -70,14 +74,15 @@ can either install the project in editable mode or use the provided
 ``requirements.txt`` file:
 
 ```bash
-pip install .
+pip install .[plot]
 # or
 pip install -r requirements.txt
 ```
 
 After that simply run ``pytest`` from the repository root.  The suite adjusts
 ``sys.path`` automatically so running ``pytest`` directly works without using
-``python -m``.  ``matplotlib`` is required for the plot-related tests.
+``python -m``.  The optional ``plot`` extra installs ``matplotlib`` so the
+plot-related tests can run.
 
 ```bash
 pytest
@@ -102,7 +107,8 @@ plot-bmi-history <nombre>
 ```
 You can add ``--lang en`` to show the output in English.
 
-Make sure ``matplotlib`` is installed to view the graph.
+Install the project with ``pip install .[plot]`` so ``matplotlib`` is available
+to display the graph.
 
 ## Analyzing recent history
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ readme = "README.md"
 requires-python = ">=3.8"
 authors = [ { name = "BMI Project Contributors" } ]
 license = { file = "LICENSE" }
-dependencies = [
+dependencies = []
+
+[project.optional-dependencies]
+plot = [
     "matplotlib"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-matplotlib
+.[plot]

--- a/tests/test_plot_history.py
+++ b/tests/test_plot_history.py
@@ -1,8 +1,9 @@
 import csv
-import matplotlib.pyplot as plt
+import pytest
 import plot_bmi_history as ph
 import bmi
-import pytest
+
+plt = pytest.importorskip("matplotlib.pyplot")
 
 
 def _write_records(path, bmis):


### PR DESCRIPTION
## Summary
- move matplotlib from dependencies to an extra named `plot`
- document using `pip install .[plot]` for plotting
- install the extra in CI
- skip plotting tests if matplotlib isn't installed

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f3be6c4048322bd4b5f1f177f3636