### PR TITLE
Fix classification key normalization

### DIFF
--- a/bmi.py
+++ b/bmi.py
@@ -209,7 +209,7 @@ def mostrar_historial(nombre, base_dir="registros"):
         bmi = reg.get("bmi", "-")
         clasificacion = reg.get("clasificacion", "-")
         if clasificacion != "-":
-            clasificacion = msj("cat_" + clasificacion)
+            clasificacion = msj("cat_" + clasificacion.lower())
         print(f" {fecha} -> BMI {bmi} ({clasificacion})")
     print()
 
@@ -275,7 +275,7 @@ def main(argv=None):
         bmi = calcular_bmi(peso, altura)
         print(msj("tu_bmi", bmi=bmi))
         clasificacion = clasificar_bmi(bmi)
-        clasificacion_label = msj("cat_" + clasificacion)
+        clasificacion_label = msj("cat_" + clasificacion.lower())
         print(msj("clasificacion", clasificacion=clasificacion_label))
         consejo_key = obtener_consejo(clasificacion)
         if consejo_key:

--- a/plot_bmi_history.py
+++ b/plot_bmi_history.py
@@ -117,8 +117,8 @@ def analizar_registros_recientes(nombre, semanas=4, base_dir="registros"):
     idx_primera = orden.index(primera)
     idx_ultima = orden.index(ultima)
 
-    primera_label = msj("cat_" + primera)
-    ultima_label = msj("cat_" + ultima)
+    primera_label = msj("cat_" + primera.lower())
+    ultima_label = msj("cat_" + ultima.lower())
 
     if idx_ultima < idx_primera:
         cambio = msj("mejora", primera=primera_label, ultima=ultima_label)


### PR DESCRIPTION
## Summary
- handle mixed-case classifications when showing history
- lower-case BMI classification keys when printing current result
- lower-case strings when summarizing BMI history

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684f58c0a8748322866b6b16ad0bc2c5