### PR TITLE
Add bmi-console CLI and menu tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ pip install .
 pip install .[plot]
 ```
 
-This will provide the commands ``bmi`` and ``plot-bmi-history`` which wrap the
-scripts in this repository.
+This will provide the commands ``bmi``, ``plot-bmi-history`` and ``bmi-console``
+which wrap the scripts in this repository.
 
 ## Usage
 
@@ -66,6 +66,16 @@ El BMI para 65 kg sería: 21.25
 (The highlighted cell uses inverted colours.)
 
 All completed calculations are appended to ``registros/<tu_nombre>.csv`` so you can keep track of your history. The directory can be changed with the ``--base-dir`` flag.
+
+### Menu mode
+
+You can launch a simple interactive menu with ``bmi-console`` which
+allows you to calculate a new BMI or view the stored history and graph
+for a user.
+
+```bash
+bmi-console --lang en
+```
 
 ## Running tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ plot = [
 
 [project.scripts]
 bmi = "bmi:main_cli"
-plot-bmi-history = "plot_bmi_history:main"
 bmi-console = "bmi_console:main"
+plot-bmi-history = "plot_bmi_history:main"
 
 [tool.setuptools]
 py-modules = ["bmi", "plot_bmi_history", "bmi_console"]

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,46 @@
+import bmi_console as bc
+
+
+def _patch_common(monkeypatch):
+    monkeypatch.setattr(bc.bmi, "limpiar_pantalla", lambda: None)
+    monkeypatch.setattr(bc.ph, "establecer_idioma", lambda *a, **k: None)
+
+
+def test_show_history_select_existing(monkeypatch):
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(bc.bmi, "obtener_nombres_guardados", lambda base: ["Ana"]) 
+    monkeypatch.setattr(bc.bmi, "msj", lambda k: k)
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+    calls = []
+    monkeypatch.setattr(bc.bmi, "mostrar_historial", lambda n, b: calls.append(("hist", n, b)))
+    monkeypatch.setattr(bc.ph, "plot_historial", lambda n, b: calls.append(("plot", n, b)))
+    bc._show_history_and_graph("base")
+    assert calls == [("hist", "Ana", "base"), ("plot", "Ana", "base")]
+
+
+def test_show_history_new_user(monkeypatch):
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(bc.bmi, "obtener_nombres_guardados", lambda base: ["Ana"]) 
+    monkeypatch.setattr(bc.bmi, "msj", lambda k: k)
+    inputs = iter(["0"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    monkeypatch.setattr(bc.bmi, "pedir_cadena_no_vacia", lambda prompt: "Bob")
+    calls = []
+    monkeypatch.setattr(bc.bmi, "mostrar_historial", lambda n, b: calls.append(("hist", n, b)))
+    monkeypatch.setattr(bc.ph, "plot_historial", lambda n, b: calls.append(("plot", n, b)))
+    bc._show_history_and_graph("base")
+    assert calls == [("hist", "Bob", "base"), ("plot", "Bob", "base")]
+
+
+def test_main_menu_calls_actions(monkeypatch, tmp_path):
+    _patch_common(monkeypatch)
+    calls = []
+    monkeypatch.setattr(bc.bmi, "main", lambda args: calls.append(("main", args)))
+    monkeypatch.setattr(bc, "_show_history_and_graph", lambda base: calls.append(("hist", base)))
+    inputs = iter(["1", "2", "", "3"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    bc.main(["--base-dir", str(tmp_path), "--lang", "en"])
+    assert calls == [
+        ("main", ["--base-dir", str(tmp_path), "--lang", "en"]),
+        ("hist", str(tmp_path)),
+    ]


### PR DESCRIPTION
## Summary
- expose a `bmi-console` entry point in **pyproject.toml**
- document the `bmi-console` command in README
- add tests for the console menu workflow

## Testing
- `pip install -e .[plot]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f6088338083229a61524706ee4ca9