### PR TITLE
Introduce BmiCategory enum

### DIFF
--- a/plot_bmi_history.py
+++ b/plot_bmi_history.py
@@ -4,11 +4,7 @@ from datetime import datetime, timedelta
 
 from bmi import (
     cargar_historial,
-    CAT_MUY_BAJO,
-    CAT_BAJO,
-    CAT_NORMAL,
-    CAT_ALTO,
-    CAT_MUY_ALTO,
+    BmiCategory,
 )
 
 from translations import MENSAJES, establecer_idioma, msj
@@ -51,12 +47,23 @@ def analizar_registros_recientes(nombre, semanas=4, base_dir="registros"):
     primera = recientes_sorted[0]["clasificacion"]
     ultima = recientes_sorted[-1]["clasificacion"]
 
-    orden = [CAT_MUY_BAJO, CAT_BAJO, CAT_NORMAL, CAT_ALTO, CAT_MUY_ALTO]
+    if not isinstance(primera, BmiCategory):
+        primera = BmiCategory(str(primera))
+    if not isinstance(ultima, BmiCategory):
+        ultima = BmiCategory(str(ultima))
+
+    orden = [
+        BmiCategory.MUY_BAJO,
+        BmiCategory.BAJO,
+        BmiCategory.NORMAL,
+        BmiCategory.ALTO,
+        BmiCategory.MUY_ALTO,
+    ]
     idx_primera = orden.index(primera)
     idx_ultima = orden.index(ultima)
 
-    primera_label = msj("cat_" + primera.lower())
-    ultima_label = msj("cat_" + ultima.lower())
+    primera_label = msj("cat_" + primera.value)
+    ultima_label = msj("cat_" + ultima.value)
 
     if idx_ultima < idx_primera:
         cambio = msj("mejora", primera=primera_label, ultima=ultima_label)

--- a/tests/test_bmi.py
+++ b/tests/test_bmi.py
@@ -7,11 +7,7 @@ from bmi import (
     pedir_cadena_no_vacia,
     calcular_rango_peso_saludable,
     calcular_bmi_para_usuario,
-    CAT_MUY_BAJO,
-    CAT_BAJO,
-    CAT_NORMAL,
-    CAT_ALTO,
-    CAT_MUY_ALTO,
+    BmiCategory,
 )
 
 
@@ -23,14 +19,14 @@ def test_calcular_bmi_known_values():
 @pytest.mark.parametrize(
     "bmi_value, expected",
     [
-        (15.9, CAT_MUY_BAJO),
-        (16, CAT_BAJO),
-        (18.4, CAT_BAJO),
-        (18.5, CAT_NORMAL),
-        (24.9, CAT_NORMAL),
-        (25, CAT_ALTO),
-        (29.9, CAT_ALTO),
-        (30, CAT_MUY_ALTO),
+        (15.9, BmiCategory.MUY_BAJO),
+        (16, BmiCategory.BAJO),
+        (18.4, BmiCategory.BAJO),
+        (18.5, BmiCategory.NORMAL),
+        (24.9, BmiCategory.NORMAL),
+        (25, BmiCategory.ALTO),
+        (29.9, BmiCategory.ALTO),
+        (30, BmiCategory.MUY_ALTO),
     ],
 )
 def test_clasificar_bmi_boundaries(bmi_value, expected):
@@ -55,6 +51,6 @@ def test_calcular_bmi_para_usuario(tmp_path, monkeypatch):
     monkeypatch.setattr("bmi.imprimir_tabla_bmi", lambda *a, **k: None)
     bmi_val, clasif = calcular_bmi_para_usuario("Ana", base_dir=str(tmp_path))
     assert bmi_val == pytest.approx(22.8571, rel=1e-3)
-    assert clasif == CAT_NORMAL
+    assert clasif == BmiCategory.NORMAL
     registros = bmi.cargar_historial("Ana", str(tmp_path))
     assert len(registros) == 1

--- a/tests/test_plot_history.py
+++ b/tests/test_plot_history.py
@@ -2,6 +2,7 @@ import csv
 import pytest
 import plot_bmi_history as ph
 import bmi
+from bmi import BmiCategory
 
 plt = pytest.importorskip("matplotlib.pyplot")
 
@@ -28,7 +29,7 @@ def _write_records(path, bmis):
                     "peso": "70",
                     "altura": "1.70",
                     "bmi": bmi_val,
-                    "clasificacion": bmi.CAT_NORMAL,
+                    "clasificacion": BmiCategory.NORMAL.value,
                 }
             )
 

--- a/tests/test_recent.py
+++ b/tests/test_recent.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import plot_bmi_history as ph
 import bmi
+from bmi import BmiCategory
 
 analizar_registros_recientes = ph.analizar_registros_recientes
 
@@ -10,12 +11,12 @@ def test_analizar_recientes_mejora(capsys, monkeypatch):
         {
             "fecha": "2024-01-01T00:00:00",
             "bmi": 31,
-            "clasificacion": bmi.CAT_MUY_ALTO,
+            "clasificacion": BmiCategory.MUY_ALTO,
         },
         {
             "fecha": "2024-01-15T00:00:00",
             "bmi": 29,
-            "clasificacion": bmi.CAT_ALTO,
+            "clasificacion": BmiCategory.ALTO,
         },
     ]
     monkeypatch.setattr(
@@ -39,12 +40,12 @@ def test_analizar_recientes_empeora(capsys, monkeypatch):
         {
             "fecha": "2024-01-01T00:00:00",
             "bmi": 22,
-            "clasificacion": bmi.CAT_NORMAL,
+            "clasificacion": BmiCategory.NORMAL,
         },
         {
             "fecha": "2024-02-01T00:00:00",
             "bmi": 27,
-            "clasificacion": bmi.CAT_ALTO,
+            "clasificacion": BmiCategory.ALTO,
         },
     ]
     monkeypatch.setattr(
@@ -85,7 +86,7 @@ def test_analizar_recientes_no_suficientes(capsys, monkeypatch):
         {
             "fecha": "2024-01-01T00:00:00",
             "bmi": 31,
-            "clasificacion": bmi.CAT_MUY_ALTO,
+            "clasificacion": BmiCategory.MUY_ALTO,
         },
     ]
     monkeypatch.setattr(

--- a/tests/test_storage_and_names.py
+++ b/tests/test_storage_and_names.py
@@ -8,7 +8,7 @@ from bmi import (
     mostrar_historial,
     calcular_rango_peso_saludable,
     sanitize_nombre,
-    CAT_NORMAL,
+    BmiCategory,
 )
 
 
@@ -28,7 +28,7 @@ def test_guardar_y_cargar_registro(tmp_path):
         70,
         1.75,
         22.86,
-        CAT_NORMAL,
+        BmiCategory.NORMAL,
         base_dir=str(base),
     )
     archivo = base / "Ana_Maria.csv"
@@ -40,7 +40,7 @@ def test_guardar_y_cargar_registro(tmp_path):
     assert float(r["peso"]) == pytest.approx(70)
     assert float(r["altura"]) == pytest.approx(1.75)
     assert float(r["bmi"]) == pytest.approx(22.86, rel=1e-2)
-    assert r["clasificacion"] == CAT_NORMAL
+    assert r["clasificacion"] == BmiCategory.NORMAL
 
 
 def test_mostrar_historial(capsys, tmp_path):
@@ -50,7 +50,7 @@ def test_mostrar_historial(capsys, tmp_path):
         80,
         1.8,
         24.69,
-        CAT_NORMAL,
+        BmiCategory.NORMAL,
         base_dir=str(base),
     )
     mostrar_historial("Jose", str(base))
@@ -85,7 +85,7 @@ def test_sanitization_consistency(tmp_path, monkeypatch):
         70,
         1.75,
         22.86,
-        CAT_NORMAL,
+        BmiCategory.NORMAL,
         base_dir=str(tmp_path),
     )
     cargar_historial(nombre, str(tmp_path))

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,8 +1,9 @@
 import bmi
+from bmi import BmiCategory
 
 
 def test_imprimir_tabla_bmi_output(capsys):
-    bmi.imprimir_tabla_bmi(22.86, bmi.CAT_NORMAL)
+    bmi.imprimir_tabla_bmi(22.86, BmiCategory.NORMAL)
     out = capsys.readouterr().out
     lines = out.splitlines()
     width = 12


### PR DESCRIPTION
## Summary
- add `BmiCategory` Enum to bmi.py
- update BMI logic and plotting code to use the enum
- save enum values when writing CSV history
- adjust history loading to return enum members
- rewrite tests to reference the new enum

## Testing
- `pip install -q '.[plot]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68519c3f32c88322939def291b54f035