### PR TITLE
Add bmi-recent CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install .
 pip install .[plot]
 ```
 
-This will provide the commands ``bmi``, ``plot-bmi-history`` and ``bmi-console``
+This will provide the commands ``bmi``, ``plot-bmi-history``, ``bmi-console`` and ``bmi-recent``
 which wrap the scripts in this repository.
 
 ## Usage
@@ -126,10 +126,10 @@ The helper module also provides ``analizar_registros_recientes`` which inspects
 the last few weeks of stored data. It prints whether your BMI is rising,
 falling or stable and reports any change in BMI classification.
 
-Example usage:
+After installation you can invoke it directly with ``bmi-recent``:
 
 ```bash
-python -c "import plot_bmi_history as ph; ph.analizar_registros_recientes('Tania')"
+bmi-recent Tania --weeks 8 --lang en
 ```
 
 ## Contributing

--- a/plot_bmi_history.py
+++ b/plot_bmi_history.py
@@ -138,5 +138,31 @@ def main(argv=None):
     plot_historial(args.nombre, args.base_dir)
 
 
+def main_recent(argv=None):
+    """Entry point for the ``bmi-recent`` console command."""
+    parser = argparse.ArgumentParser(
+        description="Analiza los registros recientes de un usuario"
+    )
+    parser.add_argument("nombre", help="Nombre del usuario")
+    parser.add_argument(
+        "--weeks",
+        type=int,
+        default=4,
+        help="Numero de semanas a analizar",
+    )
+    parser.add_argument(
+        "--base-dir", default="registros", help="Directorio con registros"
+    )
+    parser.add_argument(
+        "--lang",
+        default="es",
+        choices=MENSAJES.keys(),
+        help="Idioma de los mensajes",
+    )
+    args = parser.parse_args(argv)
+    establecer_idioma(args.lang)
+    analizar_registros_recientes(args.nombre, args.weeks, args.base_dir)
+
+
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ plot = [
 bmi = "bmi:main_cli"
 bmi-console = "bmi_console:main"
 plot-bmi-history = "plot_bmi_history:main"
+bmi-recent = "plot_bmi_history:main_recent"
 
 [tool.setuptools]
 py-modules = ["bmi", "plot_bmi_history", "bmi_console", "translations"]

--- a/tests/test_recent.py
+++ b/tests/test_recent.py
@@ -103,3 +103,44 @@ def test_analizar_recientes_no_suficientes(capsys, monkeypatch):
     analizar_registros_recientes("Ana", semanas=8)
     out = capsys.readouterr().out
     assert "No hay suficientes registros" in out
+
+
+def test_main_recent_lang_en(monkeypatch, capsys):
+    registros = [
+        {
+            "fecha": "2024-01-01T00:00:00",
+            "bmi": 31,
+            "clasificacion": BmiCategory.MUY_ALTO,
+        },
+        {
+            "fecha": "2024-01-15T00:00:00",
+            "bmi": 29,
+            "clasificacion": BmiCategory.ALTO,
+        },
+    ]
+    monkeypatch.setattr(
+        "plot_bmi_history.cargar_historial",
+        lambda nombre, base_dir="registros": registros,
+    )
+
+    class DummyDate(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2024, 2, 1)
+
+    monkeypatch.setattr(ph, "datetime", DummyDate)
+    ph.main_recent(["Ana", "--weeks", "8", "--lang", "en"])
+    out = capsys.readouterr().out
+    assert "improved" in out
+    ph.establecer_idioma("es")
+
+
+def test_main_recent_passes_arguments(monkeypatch):
+    captured = {}
+
+    def fake_an(nombre, semanas=4, base_dir="registros"):
+        captured["args"] = (nombre, semanas, base_dir)
+
+    monkeypatch.setattr(ph, "analizar_registros_recientes", fake_an)
+    ph.main_recent(["Bob", "--weeks", "6", "--base-dir", "foo"])
+    assert captured["args"] == ("Bob", 6, "foo")


### PR DESCRIPTION
## Summary
- expose `analizar_registros_recientes` through new `bmi-recent` command
- register the new console script
- document how to use `bmi-recent`
- test `main_recent` behaviour

## Testing
- `pip install -e .[plot]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851a705c0f4832297ccd8b4a333b012