### PR TITLE
Fix flake8 warnings and trim file endings

### DIFF
--- a/bmi.py
+++ b/bmi.py
@@ -131,10 +131,13 @@ def mostrar_historial(nombre, base_dir="registros"):
 
 
 def calcular_bmi_para_usuario(nombre, base_dir="registros"):
-    """Solicita datos al usuario, guarda el registro y devuelve BMI y clasificación."""
+    """Solicita datos al usuario, guarda el registro y devuelve BMI y
+    clasificación."""
 
     peso = pedir_float_positivo(msj("pregunta_peso"), min_val=30, max_val=300)
-    altura = pedir_float_positivo(msj("pregunta_altura"), min_val=0.5, max_val=2.5)
+    altura = pedir_float_positivo(
+        msj("pregunta_altura"), min_val=0.5, max_val=2.5
+    )
 
     print(msj("peso_ingresado", peso=peso))
     print(msj("altura_ingresada", altura=altura))

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -8,26 +8,50 @@ def _patch_common(monkeypatch):
 
 def test_show_history_select_existing(monkeypatch):
     _patch_common(monkeypatch)
-    monkeypatch.setattr(bc.bmi, "obtener_nombres_guardados", lambda base: ["Ana"]) 
+    monkeypatch.setattr(
+        bc.bmi,
+        "obtener_nombres_guardados",
+        lambda base: ["Ana"],
+    )
     monkeypatch.setattr(bc.bmi, "msj", lambda k: k)
     monkeypatch.setattr("builtins.input", lambda _: "1")
     calls = []
-    monkeypatch.setattr(bc.bmi, "mostrar_historial", lambda n, b: calls.append(("hist", n, b)))
-    monkeypatch.setattr(bc.ph, "plot_historial", lambda n, b: calls.append(("plot", n, b)))
+    monkeypatch.setattr(
+        bc.bmi,
+        "mostrar_historial",
+        lambda n, b: calls.append(("hist", n, b)),
+    )
+    monkeypatch.setattr(
+        bc.ph,
+        "plot_historial",
+        lambda n, b: calls.append(("plot", n, b)),
+    )
     bc._show_history_and_graph("base")
     assert calls == [("hist", "Ana", "base"), ("plot", "Ana", "base")]
 
 
 def test_show_history_new_user(monkeypatch):
     _patch_common(monkeypatch)
-    monkeypatch.setattr(bc.bmi, "obtener_nombres_guardados", lambda base: ["Ana"]) 
+    monkeypatch.setattr(
+        bc.bmi,
+        "obtener_nombres_guardados",
+        lambda base: ["Ana"],
+    )
     monkeypatch.setattr(bc.bmi, "msj", lambda k: k)
     inputs = iter(["0"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
     monkeypatch.setattr(bc.bmi, "pedir_cadena_no_vacia", lambda prompt: "Bob")
     calls = []
-    monkeypatch.setattr(bc.bmi, "mostrar_historial", lambda n, b: calls.append(("hist", n, b)))
-    monkeypatch.setattr(bc.ph, "plot_historial", lambda n, b: calls.append(("plot", n, b)))
+    monkeypatch.setattr(
+        bc.bmi,
+        "mostrar_historial",
+        lambda n, b: calls.append(("hist", n, b)),
+    )
+    monkeypatch.setattr(
+        bc.ph,
+        "plot_historial",
+        lambda n, b: calls.append(("plot", n, b)),
+    )
     bc._show_history_and_graph("base")
     assert calls == [("hist", "Bob", "base"), ("plot", "Bob", "base")]
 
@@ -35,8 +59,16 @@ def test_show_history_new_user(monkeypatch):
 def test_main_menu_calls_actions(monkeypatch, tmp_path):
     _patch_common(monkeypatch)
     calls = []
-    monkeypatch.setattr(bc.bmi, "main", lambda args: calls.append(("main", args)))
-    monkeypatch.setattr(bc, "_show_history_and_graph", lambda base: calls.append(("hist", base)))
+    monkeypatch.setattr(
+        bc.bmi,
+        "main",
+        lambda args: calls.append(("main", args)),
+    )
+    monkeypatch.setattr(
+        bc,
+        "_show_history_and_graph",
+        lambda base: calls.append(("hist", base)),
+    )
     inputs = iter(["1", "2", "", "3"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
     bc.main(["--base-dir", str(tmp_path), "--lang", "en"])

--- a/tests/test_plot_history.py
+++ b/tests/test_plot_history.py
@@ -1,7 +1,6 @@
 import csv
 import pytest
 import plot_bmi_history as ph
-import bmi
 from bmi import BmiCategory
 
 plt = pytest.importorskip("matplotlib.pyplot")

--- a/tests/test_recent.py
+++ b/tests/test_recent.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import plot_bmi_history as ph
-import bmi
 from bmi import BmiCategory
 
 analizar_registros_recientes = ph.analizar_registros_recientes

--- a/translations.py
+++ b/translations.py
@@ -139,4 +139,3 @@ def establecer_idioma(idioma):
 def msj(clave, **kwargs):
     """Return the translated message for ``clave``."""
     return MENSAJES[_IDIOMA][clave].format(**kwargs)
-


### PR DESCRIPTION
## Summary
- wrap long lines in test_console
- wrap BMI utility lines and docstring
- drop unused imports from tests
- remove final blank line in translations

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68541d1eefbc8322ae3ba6a091f68bec