### PR TITLE
Improve test instructions and handle missing matplotlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ bmi-console --lang en
 
 ## Running tests
 
-Before invoking the test suite make sure the dependencies are installed.  You
-can either install the project in editable mode or use the provided
-``requirements.txt`` file:
+Before invoking the test suite make sure the optional plotting dependencies are
+installed as well.  Several tests rely on ``matplotlib`` so you must either add
+the ``plot`` extra or use the provided ``requirements.txt`` file:
 
 ```bash
 pip install .[plot]

--- a/plot_bmi_history.py
+++ b/plot_bmi_history.py
@@ -1,5 +1,13 @@
 import argparse
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ModuleNotFoundError:
+    plt = None
+
+_MPL_MISSING_MSG = (
+    "matplotlib is required. Install with 'pip install .[plot]' or "
+    "'pip install -r requirements.txt'"
+)
 from datetime import datetime, timedelta
 
 from bmi import (
@@ -90,6 +98,8 @@ def analizar_registros_recientes(nombre, semanas=4, base_dir="registros"):
 
 
 def plot_historial(nombre, base_dir="registros"):
+    if plt is None:
+        raise SystemExit(_MPL_MISSING_MSG)
     registros = cargar_historial(nombre, base_dir)
     if not registros:
         print(msj("no_historial", nombre=nombre))


### PR DESCRIPTION
## Summary
- note the extra dependencies required to run tests
- exit gracefully in `plot_bmi_history.py` if matplotlib is not installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68541edc0ee8832296f9d4f69db62ee0