### PR TITLE
Handle invalid language codes

### DIFF
--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,6 +1,7 @@
 import bmi
 import plot_bmi_history as ph
 import translations
+import pytest
 
 
 def test_shared_translation_objects():
@@ -13,3 +14,12 @@ def test_language_switch_affects_both():
     assert ph.msj("rising") == translations.MENSAJES["en"]["rising"]
     ph.establecer_idioma("es")
     assert bmi.msj("falling") == translations.MENSAJES["es"]["falling"]
+
+
+def test_invalid_language_raises_error():
+    current = translations.msj("titulo")
+    with pytest.raises(ValueError):
+        translations.establecer_idioma("fr")
+    # language should remain unchanged
+    assert translations.msj("titulo") == current
+

--- a/translations.py
+++ b/translations.py
@@ -134,6 +134,10 @@ def establecer_idioma(idioma):
     global _IDIOMA
     if idioma in MENSAJES:
         _IDIOMA = idioma
+    else:
+        raise ValueError(
+            f"Unsupported language code '{idioma}'. Available languages: {', '.join(MENSAJES)}"
+        )
 
 
 def msj(clave, **kwargs):


### PR DESCRIPTION
## Summary
- raise a `ValueError` when `establecer_idioma` receives an unsupported code
- test invalid language error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854205b3a04832282b8b265e270a8b9